### PR TITLE
Fix BlackboardEntrySelector entryType mapping behavior

### DIFF
--- a/Runtime/Blackboard/Blackboard.cs
+++ b/Runtime/Blackboard/Blackboard.cs
@@ -13,6 +13,7 @@ namespace Schema.Internal
     {
         private static Type[] _blackboardTypes;
         private static Type[] _mappedBlackboardTypes;
+        private static Blackboard _global;
         [SerializeField] private BlackboardEntry[] m_entries = Array.Empty<BlackboardEntry>();
 
         public static Type[] blackboardTypes =>
@@ -26,6 +27,8 @@ namespace Schema.Internal
         ///     Array of entries for the Blackboard
         /// </summary>
         public BlackboardEntry[] entries => m_entries;
+
+        public static Blackboard global => _global == null ? _global = LoadGlobal() : _global;
 
         private void OnEnable()
         {
@@ -42,14 +45,12 @@ namespace Schema.Internal
         {
             return blackboardTypes.Select(x => EntryType.GetMappedType(x)).ToArray();
         }
-        public static Blackboard global => _global == null ? _global = LoadGlobal() : _global;
-        private static Blackboard _global;
 
         private static Blackboard LoadGlobal()
         {
             Blackboard loaded = Resources.Load<Blackboard>("GlobalBlackboard");
 
-            #if UNITY_EDITOR
+#if UNITY_EDITOR
             if (loaded == null)
             {
                 loaded = CreateInstance<Blackboard>();
@@ -59,13 +60,13 @@ namespace Schema.Internal
 
                 AssetDatabase.CreateAsset(loaded, "Assets/Resources/GlobalBlackboard.asset");
             }
-            #endif
+#endif
 
             return loaded;
         }
 
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         public static Blackboard instance;
 
         public delegate void EntryListChangedCallback(Blackboard changed);
@@ -74,8 +75,8 @@ namespace Schema.Internal
 
         public static event EntryListChangedCallback entryListChanged;
         public static event EntryTypeChangedCallback entryTypeChanged;
-        #endif
-        #if UNITY_EDITOR
+#endif
+#if UNITY_EDITOR
         public int GetTypeMask(IEnumerable<string> filters)
         {
             List<Type> typeArray = filters.Select(s => Type.GetType(s)).ToList();
@@ -172,6 +173,6 @@ namespace Schema.Internal
         {
             entryTypeChanged?.Invoke(entry);
         }
-        #endif
+#endif
     }
 }

--- a/Runtime/Blackboard/BlackboardEntry.cs
+++ b/Runtime/Blackboard/BlackboardEntry.cs
@@ -32,11 +32,10 @@ namespace Schema.Internal
         {
             get
             {
-                if (_type == null || !lastTypeString.Equals(m_typeString))
-                {
-                    _type = Type.GetType(m_typeString);
-                    lastTypeString = m_typeString;
-                }
+                if (_type != null && lastTypeString.Equals(m_typeString)) return _type;
+
+                _type = Type.GetType(m_typeString);
+                lastTypeString = m_typeString;
 
                 return _type;
             }

--- a/Runtime/Blackboard/BlackboardEntrySelector.cs
+++ b/Runtime/Blackboard/BlackboardEntrySelector.cs
@@ -97,7 +97,9 @@ namespace Schema
         [SerializeField] private string m_dynamicName;
         [SerializeField] private bool m_isDynamic;
         [SerializeField] private List<string> m_filters;
-        private string lastEntryTypeString;
+        private Type _lastEntryTypeMapped;
+
+        private Type _lastEntryTypeUnmapped;
 
         /// <summary>
         ///     Whether the entry attached to this selector is null
@@ -142,7 +144,23 @@ namespace Schema
         /// </summary>
         public string dynamicName => m_dynamicName;
 
-        public Type entryType => entry == null ? null : entry.type;
+        public Type entryType
+        {
+            get
+            {
+                if (!entry)
+                    return null;
+
+                Type entryTypeUnmapped = entry.type;
+                if (_lastEntryTypeUnmapped == entryTypeUnmapped)
+                    return _lastEntryTypeMapped;
+
+                _lastEntryTypeMapped = EntryType.GetMappedType(entryTypeUnmapped);
+                _lastEntryTypeUnmapped = entryType;
+
+                return _lastEntryTypeMapped;
+            }
+        }
 
         /// <summary>
         ///     The value of this selector (runtime only)
@@ -151,52 +169,44 @@ namespace Schema
         {
             get
             {
-                if (!Application.isPlaying || (!m_isDynamic && m_entry == null))
+                if (!Application.isPlaying || (!m_isDynamic && !m_entry))
                     return null;
 
-                if (m_isDynamic) return ExecutableTree.current.blackboard.GetDynamic(m_dynamicName);
+                if (m_isDynamic)
+                    return ExecutableTree.current.blackboard.GetDynamic(m_dynamicName);
 
-                if (entry != null)
-                {
-                    object obj = ExecutableTree.current.blackboard.Get(m_entry);
+                object obj = ExecutableTree.current.blackboard.Get(m_entry);
 
-                    if (obj == null)
-                        return null;
+                if (obj == null)
+                    return null;
 
-                    string vPath = new Regex(@" \(.*\)$").Replace(m_valuePath, "");
+                string vPath = new Regex(@" \(.*\)$").Replace(m_valuePath, "");
 
-                    if (!string.IsNullOrEmpty(m_valuePath))
-                        return DynamicProperty.Get(obj, vPath);
-
-                    return obj;
-                }
-
-                return null;
+                return !string.IsNullOrEmpty(m_valuePath) ? DynamicProperty.Get(obj, vPath) : obj;
             }
             set
             {
-                if (!Application.isPlaying || (!m_isDynamic && m_entry == null))
+                if (!Application.isPlaying || (!m_isDynamic && !m_entry))
                     return;
 
                 if (m_isDynamic)
                 {
                     ExecutableTree.current.blackboard.SetDynamic(m_dynamicName, value);
+                    return;
                 }
-                else if (m_entry != null)
+
+                if (!string.IsNullOrEmpty(m_valuePath.Trim('/')))
                 {
-                    if (!string.IsNullOrEmpty(m_valuePath.Trim('/')))
-                    {
-                        object valueObj = ExecutableTree.current.blackboard.Get(m_entry);
+                    object valueObj = ExecutableTree.current.blackboard.Get(m_entry);
 
-                        if (valueObj == null)
-                            return;
+                    if (valueObj == null)
+                        return;
 
-                        DynamicProperty.Set(valueObj, m_valuePath, value);
-                    }
-                    else
-                    {
-                        ExecutableTree.current.blackboard.Set(m_entry, value);
-                    }
+                    DynamicProperty.Set(valueObj, m_valuePath, value);
+                }
+                else
+                {
+                    ExecutableTree.current.blackboard.Set(m_entry, value);
                 }
             }
         }
@@ -265,9 +275,7 @@ namespace Schema
             if (!Application.isEditor)
                 return;
 
-            Type t = GetType();
-
-            if (t != typeof(BlackboardEntrySelector))
+            if (GetType() != typeof(BlackboardEntrySelector))
             {
                 Debug.LogWarning(
                     "Applying filters to a generic selector or component selector is not allowed. To use custom filters, create a non-generic BlackboardEntrySelector instead."
@@ -275,23 +283,19 @@ namespace Schema
                 return;
             }
 
-            m_filters.Clear();
+            IEnumerable<Type> validFilters = filters.Where(t =>
+            {
+                bool b = Blackboard.mappedBlackboardTypes.Contains(t);
+                if (!b)
+                    Debug.LogWarning(
+                        $"Type {t.Name} is not a valid Blackboard type and therefore is not allowed to be used as a filter");
+                return b;
+            }).ToList();
 
-            if (entryType != null && !filters.Contains(EntryType.GetMappedType(entryType)))
+            m_filters = validFilters.Select(t => t.AssemblyQualifiedName).ToList();
+
+            if (entryType != null && !validFilters.Contains(entryType))
                 m_entry = null;
-
-            m_filters = filters
-                .Where(t =>
-                {
-                    bool b = Blackboard.mappedBlackboardTypes.Contains(t);
-
-                    if (!b)
-                        Debug.LogWarning($"Type {t.Name} is not a valid Blackboard type");
-
-                    return b;
-                })
-                .Select(t => t.AssemblyQualifiedName)
-                .ToList();
         }
 
         /// <summary>
@@ -322,8 +326,7 @@ namespace Schema
                 return;
             }
 
-            m_filters.AddRange(filters
-                .Where(t =>
+            m_filters.AddRange(filters.Where(t =>
                 {
                     bool b = Blackboard.mappedBlackboardTypes.Contains(t);
 
@@ -331,8 +334,7 @@ namespace Schema
                         Debug.LogWarning($"Type {t.Name} is not a valid Blackboard type");
 
                     return b;
-                })
-                .Select(t => t.AssemblyQualifiedName)
+                }).Select(t => t.AssemblyQualifiedName)
             );
         }
 
@@ -364,8 +366,7 @@ namespace Schema
                 return;
             }
 
-            m_filters = m_filters.Except(filters
-                .Where(t =>
+            m_filters = m_filters.Except(filters.Where(t =>
                 {
                     bool b = Blackboard.mappedBlackboardTypes.Contains(t);
 
@@ -373,8 +374,7 @@ namespace Schema
                         Debug.LogWarning($"Type {t.Name} is not a valid Blackboard type");
 
                     return b;
-                })
-                .Select(t => t.AssemblyQualifiedName)
+                }).Select(t => t.AssemblyQualifiedName)
             ).ToList();
 
             if (entryType != null && filters.Contains(EntryType.GetMappedType(entryType)))

--- a/Runtime/Blackboard/BlackboardEntrySelector.cs
+++ b/Runtime/Blackboard/BlackboardEntrySelector.cs
@@ -156,7 +156,7 @@ namespace Schema
                     return _lastEntryTypeMapped;
 
                 _lastEntryTypeMapped = EntryType.GetMappedType(entryTypeUnmapped);
-                _lastEntryTypeUnmapped = entryType;
+                _lastEntryTypeUnmapped = entryTypeUnmapped;
 
                 return _lastEntryTypeMapped;
             }

--- a/Runtime/Blackboard/EntryType.cs
+++ b/Runtime/Blackboard/EntryType.cs
@@ -26,12 +26,8 @@ namespace Schema
             if (!typeof(EntryType).IsAssignableFrom(entryType))
                 throw new ArgumentException($"{entryType.Name} does not inherit from EntryType");
 
-            Color32? customColor = entryType.GetCustomAttribute<ColorAttribute>()?.color;
-
-            if (customColor == null)
-                customColor = entryType.Name.Hash().ToColor();
-
-            return (Color32)customColor;
+            return entryType.GetCustomAttribute<ColorAttribute>()?.color ??
+                   entryType.Name.Hash().ToColor();
         }
 
         public static Type GetMappedType(Type entryType)
@@ -42,9 +38,7 @@ namespace Schema
             if (!typeof(EntryType).IsAssignableFrom(entryType))
                 throw new ArgumentException($"{entryType.Name} does not inherit from EntryType");
 
-            Type mappedType = entryType.GetCustomAttribute<UseExternalTypeDefinitionAttribute>()?.other;
-
-            return mappedType ?? entryType;
+            return entryType.GetCustomAttribute<UseExternalTypeDefinitionAttribute>()?.other ?? entryType;
         }
 
         public static string[] GetExcludedPaths(Type entryType)
@@ -52,10 +46,8 @@ namespace Schema
             if (!typeof(EntryType).IsAssignableFrom(entryType))
                 throw new ArgumentException($"{entryType.Name} does not inherit from EntryType");
 
-            string[] paths = entryType.GetCustomAttributes<ExcludePathsAttribute>()?.Select(x => x.excludedPaths)
+            return entryType.GetCustomAttributes<ExcludePathsAttribute>()?.Select(x => x.excludedPaths)
                 .SelectMany(x => x).ToArray();
-
-            return paths ?? new string[0];
         }
 
         public static Type[] GetExcludedTypes(Type entryType)
@@ -63,10 +55,8 @@ namespace Schema
             if (!typeof(EntryType).IsAssignableFrom(entryType))
                 throw new ArgumentException($"{entryType.Name} does not inherit from EntryType");
 
-            Type[] types = entryType.GetCustomAttributes<ExcludeTypesAttribute>()?.Select(x => x.excludedTypes)
+            return entryType.GetCustomAttributes<ExcludeTypesAttribute>()?.Select(x => x.excludedTypes)
                 .SelectMany(x => x).ToArray();
-
-            return types ?? new Type[0];
         }
 
         /// <summary>

--- a/Runtime/Conditionals/IsNull.cs
+++ b/Runtime/Conditionals/IsNull.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Text;
 using UnityEngine;
 
 namespace Schema.Builtin.Conditionals
 {
-    [DarkIcon("Conditionals/d_IsNull"), LightIcon("Conditionals/IsNull")]
+    [DarkIcon("Conditionals/d_IsNull")]
+    [LightIcon("Conditionals/IsNull")]
     public class IsNull : Conditional
     {
         [Tooltip("Entry to check for null")] public BlackboardEntrySelector entry = new BlackboardEntrySelector();
@@ -14,25 +14,8 @@ namespace Schema.Builtin.Conditionals
             entry.ApplyAllFilters();
         }
 
-        public override void OnInitialize(object decoratorMemory, SchemaAgent agent)
-        {
-            IsNullMemory memory = (IsNullMemory)decoratorMemory;
-
-            Type mapped = EntryType.GetMappedType(entry.entryType);
-
-            if (mapped != null)
-                memory.doReturn = mapped.IsValueType;
-            else
-                memory.doReturn = false;
-        }
-
         public override bool Evaluate(object decoratorMemory, SchemaAgent agent)
         {
-            IsNullMemory memory = (IsNullMemory)decoratorMemory;
-
-            if (memory.doReturn)
-                return true;
-
             return entry.value == null;
         }
 
@@ -53,11 +36,6 @@ namespace Schema.Builtin.Conditionals
                 sb.Append("is null");
 
             return new GUIContent(sb.ToString());
-        }
-
-        private class IsNullMemory
-        {
-            public bool doReturn;
         }
     }
 }

--- a/Runtime/Nodes/Physics/OverlapBox.cs
+++ b/Runtime/Nodes/Physics/OverlapBox.cs
@@ -28,8 +28,6 @@ namespace Schema.Builtin.Nodes
         protected override void OnObjectEnable()
         {
             hit.ApplyFilters(typeof(GameObject), typeof(List<GameObject>), typeof(Transform), typeof(List<Transform>));
-
-            ;
         }
 
         public override NodeStatus Tick(object nodeMemory, SchemaAgent agent)

--- a/Runtime/Nodes/Physics/OverlapSphere.cs
+++ b/Runtime/Nodes/Physics/OverlapSphere.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 
 namespace Schema.Builtin.Nodes
 {
-    [DarkIcon("d_SphereCollider Icon", true), LightIcon("SphereCollider Icon", true), Category("Physics"),
-     Description("Gets colliders hit by a sphere positioned in the world")]
+    [DarkIcon("d_SphereCollider Icon", true)]
+    [LightIcon("SphereCollider Icon", true)]
+    [Category("Physics")]
+    [Description("Gets colliders hit by a sphere positioned in the world")]
     public class OverlapSphere : Action
     {
         [Tooltip("Position of the sphere")] public BlackboardEntrySelector<Vector3> position;
@@ -17,8 +19,8 @@ namespace Schema.Builtin.Nodes
         [Tooltip("Specifies whether this query should hit triggers")]
         public QueryTriggerInteraction queryTriggerInteraction;
 
-        [Tooltip("BlackboardEntry to store a collection of the hit GameObjects, or the first hit GameObject"),
-         WriteOnly]
+        [Tooltip("BlackboardEntry to store a collection of the hit GameObjects, or the first hit GameObject")]
+        [WriteOnly]
         public BlackboardEntrySelector hit = new BlackboardEntrySelector();
 
         protected override void OnObjectEnable()


### PR DESCRIPTION
This pull fixes issue #5. `BlackboardEntrySelector.entryType` now returns the mapped type instead of the unmapped internal type for some `EntryType`s; i.e. a blackboard selector that has an entry with type `Schema.Internal.Types.Int` selected returns `System.Int` from the `.entryType` property instead of `Schema.Internal.Types.Int`. This takes into account type mapping using the `UseExternalTypeDefinition` attribute using existing logic.