### PR TITLE
amend valid entry selector types

### DIFF
--- a/Editor/PropertyDrawers/BlackboardEntrySelectorDrawer.cs
+++ b/Editor/PropertyDrawers/BlackboardEntrySelectorDrawer.cs
@@ -18,13 +18,12 @@ namespace SchemaEditor
         private static readonly Dictionary<string, SelectorPropertyInfo> info =
             new Dictionary<string, SelectorPropertyInfo>();
 
-        private static readonly Type[] valid = { typeof(Node), typeof(Conditional) };
+        private static readonly Type[] valid = { typeof(Node), typeof(Conditional), typeof(Modifier) };
         private static readonly CacheDictionary<Type, Type> typeMappings = new CacheDictionary<Type, Type>();
 
         private static readonly Dictionary<Type, Tuple<string[], Type[]>> excluded =
             new Dictionary<Type, Tuple<string[], Type[]>>();
 
-        private static int i;
         private static event GUIDelayCall guiDelayCall;
 
         public static void DoSelectorMenu(Rect position, SerializedProperty property, FieldInfo fieldInfo)


### PR DESCRIPTION
This pull fixes #8. `typeof(Modifier)` is added to the valid type array in `BlackboardEntrySelectorDrawer`, allowing them to be used in modifiers. Before this, LoopUntil was broken.