### PR TITLE
fix incorrect entry type when using properties

### DIFF
--- a/Runtime/Blackboard/BlackboardEntrySelector.cs
+++ b/Runtime/Blackboard/BlackboardEntrySelector.cs
@@ -97,9 +97,10 @@ namespace Schema
         [SerializeField] private string m_dynamicName;
         [SerializeField] private bool m_isDynamic;
         [SerializeField] private List<string> m_filters;
+        [SerializeField] private string m_valueTypeString;
 
-        private Type _lastEntryTypeMapped;
-        private Type _lastEntryTypeUnmapped;
+        private Type _lastValueType;
+        private string _lastValueTypeString;
 
         /// <summary>
         ///     Whether the entry attached to this selector is null
@@ -151,14 +152,13 @@ namespace Schema
                 if (!entry)
                     return null;
 
-                Type entryTypeUnmapped = entry.type;
-                if (_lastEntryTypeUnmapped == entryTypeUnmapped)
-                    return _lastEntryTypeMapped;
+                if (m_valueTypeString == _lastValueTypeString)
+                    return _lastValueType;
 
-                _lastEntryTypeMapped = EntryType.GetMappedType(entryTypeUnmapped);
-                _lastEntryTypeUnmapped = entryTypeUnmapped;
+                _lastValueTypeString = m_valueTypeString;
+                _lastValueType = Type.GetType(_lastValueTypeString);
 
-                return _lastEntryTypeMapped;
+                return _lastValueType;
             }
         }
 

--- a/Runtime/Blackboard/EntryType.cs
+++ b/Runtime/Blackboard/EntryType.cs
@@ -41,6 +41,18 @@ namespace Schema
             return entryType.GetCustomAttribute<UseExternalTypeDefinitionAttribute>()?.other ?? entryType;
         }
 
+        public static bool TryGetMappedType(Type entryType, out Type mapped)
+        {
+            if (!typeof(EntryType).IsAssignableFrom(entryType))
+            {
+                mapped = null;
+                return false;
+            }
+
+            mapped = entryType.GetCustomAttribute<UseExternalTypeDefinitionAttribute>()?.other ?? entryType;
+            return true;
+        }
+
         public static string[] GetExcludedPaths(Type entryType)
         {
             if (!typeof(EntryType).IsAssignableFrom(entryType))


### PR DESCRIPTION
`BlackboardEntrySelector.entryType` when used on a selector with a custom `valuePath` should now return the type of the property at that path instead of the type of the enclosing `BlackboardEntry`. This pull should fix issue #16.